### PR TITLE
[Bugfix] remove misleading "error" message when checking for git tag

### DIFF
--- a/lua/lvim/utils/git.lua
+++ b/lua/lvim/utils/git.lua
@@ -106,7 +106,6 @@ function M.get_lvim_tag(type)
   local lvim_full_ver = results[1] or ""
 
   if ret ~= 0 or string.match(lvim_full_ver, "%d") == nil then
-    Log:error "Unable to retrieve current tag. Check the log for further information"
     return nil
   end
   if type == "short" then


### PR DESCRIPTION
# Description
Removing a `Log:error` line that was added but is, imo, more problematic than helpful.
Having this message causes a message to be displayed as well as a notification, if enabled. This is at best annoying and at worst could cause someone(me, for instance. :) ) to spend some time figuring out why there is a problem.

## How Has This Been Tested?
1. Uninstall lunarvim with the uninstall script.
2. Install lunarvim with the install script.
3. Open lunarvim/lvim. Before this fix I was seeing a notify and a message: "Unable to retrieve current tag. Check the log for further information"